### PR TITLE
Add score reordering!

### DIFF
--- a/ap-score-hider.user.js
+++ b/ap-score-hider.user.js
@@ -1,8 +1,8 @@
 // ==UserScript==
-// @name         AP® Score Hider
+// @name         AP® Score Hider and Reorder
 // @namespace    http://tampermonkey.net/
-// @version      1.2.4
-// @description  Hides AP® Exam scores on the College Board website until you click on them. As a bonus, display confetti when you click on a passing exam.
+// @version      1.2.5
+// @description  Hides AP® Exam scores on the College Board website until you click on them, and reorders them to display 5s first. Displays confetti when you click on a passing exam.
 // @author       Samathingamajig
 // @match        https://apstudents.collegeboard.org/view-scores*
 // @icon         https://www.google.com/s2/favicons?domain=collegeboard.org
@@ -25,6 +25,17 @@
       return; // Exit program after 5 seconds of loading
     }
   } // Wait for page to load
+
+  // Reorder score containers to have 5s first
+  const parentContainer = ccontainers[0].closest('.apscores-card-col.display-flex');
+  const scoreContainers = Array.from(ccontainers).map(ccontainer => {
+    const container = ccontainer.querySelector(".apscores-badge.apscores-badge-score");
+    const score = container ? parseInt(container.textContent.trim()) : null;
+    return { ccontainer, score };
+  });
+
+  scoreContainers.sort((a, b) => b.score - a.score);
+  scoreContainers.forEach(({ ccontainer }) => parentContainer.appendChild(ccontainer.closest('.apscores-card')));
 
   for (let i = 0; i < ccontainers.length; i++) {
     // Iterate through all the score boxes


### PR DESCRIPTION
So I was thinking for the confidence and stuff it would be nice if the one at the top (and so most likely the first one you clicked) was the top score etc. that way you start with the good stuff so it hurts less getting the worst ones right? At least I feel it would be nice if it was an option (because since it's just the order you can always click on whichever one you want, you don't HAVE to click on the one at the top)

So I'm pretty sure the code I wrote should do that correctly, but the problem is I only have one AP score from last year's AP CSA (5) and so I can't test it myself because the order is always the same lol so I was wondering if someone could try and test this version of the script and let me know if it works! (and possibly merge it to main if you think it's a useful feature but even if you don't want to merge it'd be great if you could test it so I can know if it even works!)

Thank you!